### PR TITLE
Add missing `.rb` files to be bundled to active-model-adapter gem

### DIFF
--- a/active-model-adapter-source.gemspec
+++ b/active-model-adapter-source.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "ember-source", ">= 1.8", "< 3.0"
 
-  gem.files = %w(package.json) + Dir['dist/active-model*.js'] + Dir['lib/ember/data/*.rb']
+  gem.files = %w(package.json) + Dir['dist/active-model*.js'] + Dir['lib/ember/data/**/*.rb']
 end


### PR DESCRIPTION
The following files are required but not bundled now.
```
lib/ember/data/active_model/adapter/
├── source.rb
└── version.rb
```