### PR TITLE
Depend on `ember-data-source` instead of `ember-source`

### DIFF
--- a/active-model-adapter-source.gemspec
+++ b/active-model-adapter-source.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.version       = Ember::Data::ActiveModel::Adapter::VERSION
   gem.license       = "MIT"
 
-  gem.add_dependency "ember-source", ">= 1.8", "< 3.0"
+  gem.add_dependency "ember-data-source", ">= 1.13", "< 3.0"
 
   gem.files = %w(package.json) + Dir['dist/active-model*.js'] + Dir['lib/ember/data/*.rb']
 end


### PR DESCRIPTION
active-model-adapter depends on Ember Data.