### PR TITLE
Support for weird polymorphic relationship format

### DIFF
--- a/addon/active-model-serializer.js
+++ b/addon/active-model-serializer.js
@@ -300,6 +300,24 @@ var ActiveModelSerializer = RESTSerializer.extend({
       }, this);
     }
   },
+
+  extractRelationships: function(modelClass, resourceHash) {
+    modelClass.eachRelationship(function (key, relationshipMeta) {
+      var relationshipKey = this.keyForRelationship(key, relationshipMeta.kind, "deserialize");
+      if (resourceHash.hasOwnProperty(relationshipKey) && typeof resourceHash[relationshipKey] !== 'object') {
+        var polymorphicTypeKey = this.keyForRelationship(key) + '_type';
+        if (resourceHash[polymorphicTypeKey] && relationshipMeta.options.polymorphic) {
+          let id = resourceHash[relationshipKey];
+          let type = resourceHash[polymorphicTypeKey];
+          delete resourceHash[polymorphicTypeKey];
+          delete resourceHash[relationshipKey];
+          resourceHash[relationshipKey] = { id: id, type: type };
+        }
+      }
+    },this);
+    return this._super.apply(this, arguments);
+  },
+
   modelNameFromPayloadKey: function(key) {
     var convertedFromRubyModule = singularize(key.replace('::', '/'));
     return normalizeModelName(convertedFromRubyModule);


### PR DESCRIPTION
Given { some_belongs_to_id: 42, some_belongs_to_type: 'some_type' },
transforms it be conform to what the json-serializer expects, ie
{ some_belongs_to_id: { id:42, type: 'some_type'}

Fixes #18

cc/ @wecc @igorT @lessless 