### PR TITLE
Polymorphic fixes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "ember": "~1.13.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "~1.13.3",
+    "ember-data": "~1.13.5",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",

--- a/tests/integration/active-model-adapter-test.js
+++ b/tests/integration/active-model-adapter-test.js
@@ -35,7 +35,7 @@ test('handleResponse - returns invalid error if 422 response', function(assert) 
 
   var error = adapter.handleResponse(jqXHR.status, {}, json).errors[0];
 
-  assert.equal(error.details, "can't be blank");
+  assert.equal(error.detail, "can't be blank");
   assert.equal(error.source.pointer, "data/attributes/name");
 });
 

--- a/tests/integration/active-model-serializer-test.js
+++ b/tests/integration/active-model-serializer-test.js
@@ -547,7 +547,7 @@ test("extractErrors camelizes keys", function(assert) {
         source: {
           pointer: 'data/attributes/first_name'
         },
-        details: "firstName not evil enough"
+        detail: "firstName not evil enough"
       }
     ]
   };
@@ -561,4 +561,61 @@ test("extractErrors camelizes keys", function(assert) {
   assert.deepEqual(payload, {
     firstName: ["firstName not evil enough"]
   });
+});
+
+test('supports the default format for polymorphic belongsTo', function(assert) {
+  var payload = {
+    doomsday_devices: [
+      {
+        id: 1,
+        evil_minion: {
+          id: 1,
+          type: 'yellow_minion'
+        }
+      }
+    ],
+    yellow_minions: [
+      {
+        id: 1,
+        name: 'Sally'
+      }
+    ]
+  };
+  var json, minion;
+
+  run(() => {
+    json = env.amsSerializer.normalizeResponse(env.store, DoomsdayDevice, payload, '1', 'findRecord');
+    env.store.push(json);
+    minion = env.store.findRecord('doomsday-device', 1);
+  });
+
+  assert.equal(minion.get('evilMinion.name'), 'Sally');
+});
+
+test('supports the default format for polymorphic hasMany', function(assert) {
+  var payload = {
+    mediocre_villain: {
+      id: 1,
+      evil_minions: [{
+        id: 1,
+        type: 'evil_minion'
+      }]
+    },
+    evil_minions: [
+      {
+        id: 1,
+        name: 'Harry'
+      }
+    ]
+  };
+
+  var json, villain;
+
+  run(() => {
+    json = env.amsSerializer.normalizeResponse(env.store, MediocreVillain, payload, '1', 'findRecord');
+    env.store.push(json);
+    villain = env.store.findRecord('mediocre-villain', '1');
+  });
+
+  assert.equal(villain.get('evilMinions.firstObject.name'), 'Harry');
 });


### PR DESCRIPTION
Previously, the following did not load relationships correctly when using the new Serializer API:

 ```javascript
 {
  evil_minion: {
    id: 1,
    relationship_name: {
      id: 1,
      type: 'super-minion'
    }
  }
}
// push payload
store.findRecord('evil-minion', '1').then((m) => m.get('relationship.id'));
// resolves to null
```

The object format is what the AMS gem expects by default, so we return
if we find that. Otherwise, we use the "weird format" introduced by
https://github.com/ember-data/active-model-adapter/pull/20.

Fixes #15.