### PR TITLE
Set isNewSerializerAPI for ActiveModelSerializer

### DIFF
--- a/app/instance-initializers/active-model-adapter.js
+++ b/app/instance-initializers/active-model-adapter.js
@@ -24,6 +24,6 @@ export default {
     }
 
     registry.register('adapter:-active-model', ActiveModelAdapter);
-    registry.register('serializer:-active-model', ActiveModelSerializer);
+    registry.register('serializer:-active-model', ActiveModelSerializer.extend({ isNewSerializerAPI: true }));
   }
 };


### PR DESCRIPTION
in order to align it with https://github.com/ember-data/active-model-adapter/blob/master/app/initializers/active-model-adapter.js#L8.

Or is it better to just include it in ActiveModelSerializer?

cc @fivetanley 