### PR TITLE
[bugfix RELEASE] Restore polymorphic support

### DIFF
--- a/addon/active-model-serializer.js
+++ b/addon/active-model-serializer.js
@@ -292,6 +292,9 @@ var ActiveModelSerializer = RESTSerializer.extend({
           payload = hash[payloadKey];
         }
 
+        if (!payload) {
+          return;
+        }
         hash[key] = payload;
 
         if (key !== payloadKey) {

--- a/addon/active-model-serializer.js
+++ b/addon/active-model-serializer.js
@@ -292,9 +292,10 @@ var ActiveModelSerializer = RESTSerializer.extend({
           payload = hash[payloadKey];
         }
 
-        if (!payload) {
+        if (!hash.hasOwnProperty(payloadKey)) {
           return;
         }
+
         hash[key] = payload;
 
         if (key !== payloadKey) {

--- a/addon/active-model-serializer.js
+++ b/addon/active-model-serializer.js
@@ -337,9 +337,9 @@ var ActiveModelSerializer = RESTSerializer.extend({
 
 function extractPolymorphicRelationships(key, relationshipMeta, resourceHash, relationshipKey) {
   let polymorphicKey = decamelize(key);
-  if (polymorphicKey in resourceHash && typeof resourceHash[polymorphicKey] === 'object') {
+  let hash = resourceHash[polymorphicKey];
+  if (hash !== null && typeof hash === 'object') {
     if (relationshipMeta.kind === 'belongsTo') {
-      let hash = resourceHash[polymorphicKey];
       let {id, type} = hash;
       resourceHash[relationshipKey] = {id, type};
     // otherwise hasMany

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,8 @@
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.15",
     "jquery": "^1.11.1",
-    "qunit": "~1.17.1"
+    "qunit": "~1.17.1",
+    "pretender": "^0.9.0"
   },
   "devDependencies": {
     "loader.js": "~3.2.1"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ember-cli-dependency-checker": "^1.0.0",
     "ember-cli-htmlbars": "0.7.6",
     "ember-cli-inject-live-reload": "^1.3.0",
+    "ember-cli-pretender": "0.4.0",
     "ember-cli-qunit": "0.3.13",
     "ember-cli-uglify": "^1.0.1",
     "ember-data": "1.0.0-beta.18",

--- a/tests/integration/active-model-adapter-test.js
+++ b/tests/integration/active-model-adapter-test.js
@@ -36,7 +36,7 @@ test('handleResponse - returns invalid error if 422 response', function(assert) 
   var error = adapter.handleResponse(jqXHR.status, {}, json).errors[0];
 
   assert.equal(error.detail, "can't be blank");
-  assert.equal(error.source.pointer, "data/attributes/name");
+  assert.equal(error.source.pointer, "/data/attributes/name");
 });
 
 test('handleResponse - returns ajax response if not 422 response', function(assert) {

--- a/tests/integration/active-model-serializer-test.js
+++ b/tests/integration/active-model-serializer-test.js
@@ -249,6 +249,29 @@ test("normalizeResponse", function(assert) {
   });
 });
 
+test("normalizeResponse - polymorphic with empty value for polymorphic relationship", (assert) => {
+  let array;
+  const payload = {
+    doomsday_devices: [
+      {
+        id: 12,
+        evil_minion: null
+      }
+    ]
+
+  };
+
+  run(function() {
+    array = env.amsSerializer.normalizeResponse(env.store, DoomsdayDevice, payload, null, 'findAll');
+  });
+
+  run(() => env.store.push(array));
+
+  return run(() => env.store.findRecord('doomsdayDevice', 12)).then((device) => {
+    assert.equal(device.get('evilMinion'), null);
+  });
+});
+
 test("serialize polymorphic", function(assert) {
   var tom, ray;
   run(function() {

--- a/tests/integration/old-serializer-api-test.js
+++ b/tests/integration/old-serializer-api-test.js
@@ -1,0 +1,59 @@
+import Ember from 'ember';
+import DS from 'ember-data';
+import ActiveModelAdapter, {ActiveModelSerializer} from 'active-model-adapter';
+import {module, test} from 'qunit';
+import Pretender from 'pretender';
+import setupStore from '../helpers/setup-store';
+
+const {attr, hasMany} = DS;
+const {run} = Ember;
+
+Pretender.prototype.prepareBody = (body) => JSON.stringify(body);
+
+let pretender, Book, Author, env, store;
+
+module(`ActiveModelAdapter, full stack integration tests for old serializer api`, {
+  beforeEach() {
+    Book = DS.Model.extend({
+      title: attr(),
+      authors: hasMany('user', { polymorphic: true })
+    });
+    Author = DS.Model.extend({});
+    pretender = new Pretender(function(){ });
+    env = setupStore({
+      book: Book,
+      author: Author,
+      adapter: ActiveModelAdapter
+    });
+
+    env.registry.register('serializer:-active-model', ActiveModelSerializer.extend({isNewSerializerAPI: false}));
+    store = env.store;
+  }
+});
+
+// From upstream Ember Data issue: https://github.com/emberjs/data/issues/3630
+test(`does not assert if the payload key is missing for a polymorophic relationship`, (assert) => {
+  assert.expect(1);
+
+  pretender.get('/books/:id', (req) => {
+    let payload = {
+      books: [
+        { id: 1, title: 'Tom Sawyer'}
+      ],
+      authors:[
+        { id: 1, name: "Mark Twain", book_ids: [1] }
+      ]
+    };
+    let headers = {};
+
+    return [200, headers, payload];
+  });
+
+  return run(() => {
+    return store.find('book', '1').then((book) => {
+      assert.equal(book.get('title'), 'Tom Sawyer');
+    }).catch((error) => {
+      assert.ok(false, `Got error: ${error.message}`);
+    });
+  });
+});

--- a/tests/integration/old-serializer-api-test.js
+++ b/tests/integration/old-serializer-api-test.js
@@ -32,7 +32,7 @@ module(`ActiveModelAdapter, full stack integration tests for old serializer api`
 });
 
 // From upstream Ember Data issue: https://github.com/emberjs/data/issues/3630
-test(`does not assert if the payload key is missing for a polymorophic relationship`, (assert) => {
+test(`does not assert if the payload key is missing for a polymorphic relationship`, (assert) => {
   assert.expect(1);
 
   pretender.get('/books/:id', (req) => {


### PR DESCRIPTION
This fixes an issue where missing polymorphic keys in a payload would
trigger an assertion.

For example, if a Book model had a `hasMany` relationship to the Author
model, but the `authors` key was missing in the payload for a
polymorphic relationship, an assertion was incorrectly triggered.

This worked before 1.13, and this commit restores that functionality.

Fixes emberjs/data#3630

We also fixed the tests around error pointers that got updated when ember data installed to a newer version via bower. The JSONAPI spec says that error pointers must have a slash at the beginning of them.

cc @wecc