### PR TITLE
Fix babel rename option warning

### DIFF
--- a/babel-options.js
+++ b/babel-options.js
@@ -5,11 +5,10 @@ module.exports = {
   whitelist: [
     'es6.modules',
     'es6.templateLiterals',
-    'es6.parameters.rest',
+    'es6.parameters',
     'es6.arrowFunctions',
     'es6.destructuring',
     'es6.spread',
-    'es6.parameters.default',
     'es6.properties.computed',
     'es6.properties.shorthand',
     'es6.blockScoping',


### PR DESCRIPTION
Fixes:
```
[BABEL] The transformer es6.parameters.rest has been renamed to es6.parameters
[BABEL] The transformer es6.parameters.default has been renamed to es6.parameters
```