### PR TITLE
Remove unused container in instance initializer, fixes #40

### DIFF
--- a/app/instance-initializers/active-model-adapter.js
+++ b/app/instance-initializers/active-model-adapter.js
@@ -4,23 +4,17 @@ import ActiveModelSerializer from 'active-model-adapter/active-model-serializer'
 export default {
   name: 'active-model-adapter',
   initialize: function(applicationOrRegistry) {
-    var registry, container;
-    if (applicationOrRegistry.registry && applicationOrRegistry.container) {
+    var registry;
+    if (applicationOrRegistry.registry) {
       // initializeStoreService was registered with an
       // instanceInitializer. The first argument is the application
       // instance.
       registry = applicationOrRegistry.registry;
-      container = applicationOrRegistry.container;
     } else {
       // initializeStoreService was called by an initializer instead of
       // an instanceInitializer. The first argument is a registy. This
       // case allows ED to support Ember pre 1.12
       registry = applicationOrRegistry;
-      if (registry.container) { // Support Ember 1.10 - 1.11
-        container = registry.container();
-      } else { // Support Ember 1.9
-        container = registry;
-      }
     }
 
     registry.register('adapter:-active-model', ActiveModelAdapter);


### PR DESCRIPTION
Container is not used in the instance initializer so there is no point in setting it. Also fixes  #40.