### PR TITLE
Fix initializer deprecation warning for >= ember 2.1.0

### DIFF
--- a/app/initializers/active-model-adapter.js
+++ b/app/initializers/active-model-adapter.js
@@ -3,8 +3,9 @@ import ActiveModelSerializer from "active-model-adapter/active-model-serializer"
 
 export default {
   name: 'active-model-adapter',
-  initialize: function(registry, application) {
-    registry.register('adapter:-active-model', ActiveModelAdapter);
-    registry.register('serializer:-active-model', ActiveModelSerializer.extend({ isNewSerializerAPI: true }));
+  initialize: function() {
+    var application = arguments[1] || arguments[0];
+    application.register('adapter:-active-model', ActiveModelAdapter);
+    application.register('serializer:-active-model', ActiveModelSerializer.extend({ isNewSerializerAPI: true }));
   }
 };


### PR DESCRIPTION
Only application instance is passed to `initialize` method after `ember 2.1.0-beta`, this fixes the deprecation warning in a backwards compatible way.

```
DEPRECATION: The `initialize` method for Application initializer 'container-debug-adapter' should take only one argument - `App`, an instance of an `Application`. [deprecation id: ember-application.app-initializer-initialize-arguments]
```