### PR TITLE
Test against Ember Data 2.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "ember": "^2.0.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "~2.0.0",
+    "ember-data": "~2.1.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",


### PR DESCRIPTION
Ember Data 2.1 was released. :tada: 
http://emberjs.com/blog/2015/10/05/ember-data-2-1-released.html

Should active-model-adapter be also updated to 2.1?