### PR TITLE
Do not use application.registry

### DIFF
--- a/app/instance-initializers/active-model-adapter.js
+++ b/app/instance-initializers/active-model-adapter.js
@@ -4,20 +4,20 @@ import ActiveModelSerializer from 'active-model-adapter/active-model-serializer'
 export default {
   name: 'active-model-adapter',
   initialize: function(applicationOrRegistry) {
-    var registry;
-    if (applicationOrRegistry.registry) {
+    var register;
+    if (applicationOrRegistry.register) {
+      // initializeStoreService was called by an initializer instead of
+      // an instanceInitializer. The first argument is a registry for 
+      // Ember pre 1.12, or an application instance for Ember >2.1.
+      register = applicationOrRegistry.register;
+    } else {
       // initializeStoreService was registered with an
       // instanceInitializer. The first argument is the application
       // instance.
-      registry = applicationOrRegistry.registry;
-    } else {
-      // initializeStoreService was called by an initializer instead of
-      // an instanceInitializer. The first argument is a registy. This
-      // case allows ED to support Ember pre 1.12
-      registry = applicationOrRegistry;
+      register = applicationOrRegistry.registry.register;      
     }
 
-    registry.register('adapter:-active-model', ActiveModelAdapter);
-    registry.register('serializer:-active-model', ActiveModelSerializer);
+    register('adapter:-active-model', ActiveModelAdapter);
+    register('serializer:-active-model', ActiveModelSerializer);
   }
 };


### PR DESCRIPTION
Ember 2.1 deprecates application.registry as it contains private
methods. This commit replaces uses of the private registry API
with the public equivalents.