### PR TITLE
Bind instance initializer register function to the right context

### DIFF
--- a/app/instance-initializers/active-model-adapter.js
+++ b/app/instance-initializers/active-model-adapter.js
@@ -7,14 +7,14 @@ export default {
     var register;
     if (applicationOrRegistry.register) {
       // initializeStoreService was called by an initializer instead of
-      // an instanceInitializer. The first argument is a registry for 
+      // an instanceInitializer. The first argument is a registry for
       // Ember pre 1.12, or an application instance for Ember >2.1.
-      register = applicationOrRegistry.register;
+      register = applicationOrRegistry.register.bind(applicationOrRegistry);
     } else {
       // initializeStoreService was registered with an
       // instanceInitializer. The first argument is the application
       // instance.
-      register = applicationOrRegistry.registry.register;      
+      register = applicationOrRegistry.registry.register.bind(applicationOrRegistry);
     }
 
     register('adapter:-active-model', ActiveModelAdapter);

--- a/app/instance-initializers/active-model-adapter.js
+++ b/app/instance-initializers/active-model-adapter.js
@@ -9,15 +9,15 @@ export default {
       // initializeStoreService was called by an initializer instead of
       // an instanceInitializer. The first argument is a registry for
       // Ember pre 1.12, or an application instance for Ember >2.1.
-      register = applicationOrRegistry.register.bind(applicationOrRegistry);
+      register = applicationOrRegistry.register;
     } else {
       // initializeStoreService was registered with an
       // instanceInitializer. The first argument is the application
       // instance.
-      register = applicationOrRegistry.registry.register.bind(applicationOrRegistry);
+      register = applicationOrRegistry.registry.register;
     }
 
-    register('adapter:-active-model', ActiveModelAdapter);
-    register('serializer:-active-model', ActiveModelSerializer);
+    register.call(applicationOrRegistry, 'adapter:-active-model', ActiveModelAdapter);
+    register.call(applicationOrRegistry, 'serializer:-active-model', ActiveModelSerializer);
   }
 };


### PR DESCRIPTION
https://github.com/ember-data/active-model-adapter/commit/c2564d45a27da7e3525693d1f37af07373538213 broke the addon, since the register function wasn't binded to the right context.