### PR TITLE
[bugfix] support relationship names without _id suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Unlike the DS.RESTAdapter, async relationship keys must be the singular form
 of the relationship name, followed by "_id" for DS.belongsTo relationships,
 or "_ids" for DS.hasMany relationships.
 
+Since ActiveModelAdapter 2.1.0 however, you don't need the "_id" or
+"_ids" suffix on keys for relationships.
+
 ### Conventional Names
 
 Attribute names in your JSON payload should be the underscored versions of

--- a/app/initializers/active-model-adapter.js
+++ b/app/initializers/active-model-adapter.js
@@ -3,9 +3,15 @@ import ActiveModelSerializer from "active-model-adapter/active-model-serializer"
 
 export default {
   name: 'active-model-adapter',
-  initialize: function() {
-    var application = arguments[1] || arguments[0];
-    application.register('adapter:-active-model', ActiveModelAdapter);
-    application.register('serializer:-active-model', ActiveModelSerializer);
+  initialize: function(app) {
+    if (arguments.length === 1) {
+      // support the old registration API
+      app.register('adapter:-active-model', ActiveModelAdapter);
+      app.register('serializer:-active-model', ActiveModelSerializer);
+    } else {
+      let registry = app;
+      registry.register('adapter:-active-model', ActiveModelAdapter);
+      registry.register('serializer:-active-model', ActiveModelSerializer);
+    }
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-data": "~2.2.1",
     "ember-load-initializers": "0.1.7",
     "ember-qunit-notifications": "0.1.0",
-    "jquery": "^1.11.1",
+    "jquery": "~1.11.1",
     "qunit": "~1.20.0",
     "pretender": "^0.10.1"
   },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ember-try": "~0.0.8",
     "ember-watson": "^0.7.0",
     "github": "^0.2.4",
+    "loader.js": "4.0.1",
     "rsvp": "^3.1.0"
   },
   "keywords": [

--- a/tests/integration/active-model-serializer-test.js
+++ b/tests/integration/active-model-serializer-test.js
@@ -678,3 +678,50 @@ test('when using the DS.EmbeddedRecordsMixin, does not erase attributes for poly
   assert.equal(villain.get('evilMinions.firstObject.name'), 'tom dale');
 });
 
+test('can have id-less belongsTo relationship', function (assert) {
+  const payload = {
+    super_villain: {
+      id: 1,
+      home_planet: 1
+    },
+    home_planets: [
+      {
+        id: 1,
+        super_villains: [1]
+      }
+    ]
+  };
+
+  const villain = run(() => {
+    const json = env.store.serializerFor('super-villain').normalizeResponse(env.store, SuperVillain, payload, '1', 'findRecord');
+    env.store.push(json);
+    return env.store.findRecord('super-villain', 1);
+  });
+
+  assert.equal(villain.get('homePlanet.id'), '1');
+});
+
+test('can have id-less belongsTo relationship', function (assert) {
+  const payload = {
+    home_planet: {
+      id: 1,
+      super_villains: [1]
+    },
+    super_villains: [
+      {
+        id: 1,
+        home_planet: 1
+      }
+    ]
+  };
+
+  const homePlanet = run(() => {
+    const json = env.store.serializerFor('home-planet').normalizeResponse(env.store, HomePlanet, payload, '1', 'findRecord');
+    env.store.push(json);
+    return env.store.findRecord('home-planet', 1);
+  });
+
+  return homePlanet.get('superVillains').then((superVillains) => {
+    assert.deepEqual(superVillains.toArray().map(v => v.get('id')), ['1']);
+  });
+});


### PR DESCRIPTION
This means that the following would be supported:

```javascript
{
  "post": {
    // belongsTo, would normally be author_id
    "author": 1,
    // hasMany, would normally be pancake_hero_ids
    "pancake_heros": [1,2,3]
  }
}
```

Should close https://github.com/ember-data/active-model-adapter/issues/54