### PR TITLE
Fix's a regression in ember-data >= 2.4.0 related to handleResponse changes

### DIFF
--- a/addon/active-model-adapter.js
+++ b/addon/active-model-adapter.js
@@ -148,7 +148,7 @@ const ActiveModelAdapter = RESTAdapter.extend({
     @param  {Object} payload
     @return {Object | DS.AdapterError} response
   */
-  handleResponse: function(status, headers, payload) {
+  handleResponse: function(status, headers, payload, requestData) {
     if (this.isInvalid(status, headers, payload)) {
       let errors = errorsHashToArray(payload.errors);
 

--- a/tests/integration/active-model-adapter-test.js
+++ b/tests/integration/active-model-adapter-test.js
@@ -45,7 +45,12 @@ test('handleResponse - returns ajax response if not 422 response', function(asse
     responseText: "Something went wrong"
   };
 
+  var expectedRequestData = {
+    method: "GET",
+    url:    "/posts/1"
+  };
+
   var json = adapter.parseErrorResponse(jqXHR.responseText);
 
-  assert.ok(adapter.handleResponse(jqXHR.status, {}, json) instanceof DS.AdapterError, 'must be a DS.AdapterError');
+  assert.ok(adapter.handleResponse(jqXHR.status, {}, json, expectedRequestData) instanceof DS.AdapterError, 'must be a DS.AdapterError');
 });


### PR DESCRIPTION
Fix's a regression in ember-data >= 2.4.0 related to arguments changing in RESTAdapter's handleResponse function https://github.com/emberjs/data/pull/3930, pass along requestData as argument in active-model-adapter handleResponse override method as well as fix handleResponse - returns ajax response if not 422 response test

closes https://github.com/ember-data/active-model-adapter/issues/82