### PR TITLE
Add failing test for attrs hash breaking links in  >= Ember Data 2.5.0-beta.4 

### DIFF
--- a/tests/integration/active-model-serializer-test.js
+++ b/tests/integration/active-model-serializer-test.js
@@ -725,3 +725,24 @@ test('can have id-less belongsTo relationship', function (assert) {
     assert.deepEqual(superVillains.toArray().map(v => v.get('id')), ['1']);
   });
 });
+
+test('Serializer should respect the attrs hash in links', function(assert) {
+  env.registry.register('serializer:super-villain', ActiveModelSerializer.extend(DS.EmbeddedRecordsMixin, {
+
+    attrs: {
+      evilMinions: {serialize: 'records', deserialize: 'ids'}
+    }
+  }));
+
+  const payload = {
+    super_villain: {
+      firstName: 'Tom',
+      lastName: 'Dale',
+      links: { evil_minions: "/api/evil_minions/1" }
+    }
+  };
+
+  var json = env.container.lookup("serializer:super-villain").normalizeSingleResponse(env.store, SuperVillain, payload);
+
+  assert.equal(json.data.relationships.evilMinions.links.related, "/api/evil_minions/1", "normalize links");
+});


### PR DESCRIPTION
related to https://github.com/emberjs/data/pull/4268

Issue related https://github.com/ember-data/active-model-adapter/issues/84

