### PR TITLE
[BREAKING] Increase minimum Node.js version to v4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "ember try:testall"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": "^4.5 || 6.* || >= 7.*"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
This is required for many of the current releases of used addons in here and Ember, Ember Data and Ember CLI themselves.

This should be considered as a breaking change which requires us to bump the major version once released.