### PR TITLE
Add more ember-try scenarios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-2.0 # TODO fix this
     - env: EMBER_TRY_SCENARIO=ember-lts-2.12 # TODO fix this
     - env: EMBER_TRY_SCENARIO=ember-lts-2.16 # TODO fix this
     - env: EMBER_TRY_SCENARIO=ember-release # TODO fix this

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,27 @@ cache:
 
 env:
   matrix:
-  - EMBER_TRY_SCENARIO=default
-#  - EMBER_TRY_SCENARIO=ember-release
-#  - EMBER_TRY_SCENARIO=ember-beta
-#  - EMBER_TRY_SCENARIO=ember-canary
+    - EMBER_TRY_SCENARIO=default
+    - EMBER_TRY_SCENARIO=ember-2.0
+    - EMBER_TRY_SCENARIO=ember-lts-2.4
+    - EMBER_TRY_SCENARIO=ember-lts-2.8
+    - EMBER_TRY_SCENARIO=ember-lts-2.12
+    - EMBER_TRY_SCENARIO=ember-lts-2.16
+    - EMBER_TRY_SCENARIO=ember-release
+    - EMBER_TRY_SCENARIO=ember-beta
+    - EMBER_TRY_SCENARIO=ember-canary
   global:
-  - GITHUB_USER=tomster-strudel
-  - secure: A5DKT8O+wmwEY3ReKkBMFgy+r2EaUgxMd9FMR+MOGLWMzVdEm6QX0tQopWgqpoPLpymr6aUNMYrb3mRoYygBpUaobgrRRh2f+IGQ+i65+gqC+Y8ma8sArbAKVZ+QuV42ICPGTtk2ep9nQ81k1NO714iOaok4jBuTPFrIOEFx4NSWOuxAHSyjpb41YcoZ4420taXOT6PEtU528lAeLTZeI/gfn/TyDFS5Hf+CoFHxZgLZ+gtdJugu4+11KLnOPgCsAmL2AKagk3LQzfHgaASME4GqXDwz5iBloMWeP2RJJQxwUtB/XgPz//VLh1nOdfodhRy0pjeRzrgvoMYiyqKvG1UMCqjqz/WEYtdeR335NC3kPv9tCcMCeN6vvCaKoang9i+LGEFLzj+zN50ldLMfkF/YEu/PkmezYLWpQwZdlwGQpZjLabT0etS46rdSIDU3M/4N4Waj3o9G8ZXgx7fTOd9ypRPbvOBslUlzup+jMLfGoKLcdT7Cmd3qTJ7XAWFRTTGA/fM7Bd8SYY1FQBAEsHH+2HqF0RsdSAnNpXQtVdzs5TjS9jzLM2rG4S2p0Dly7fe0KgYBD/X21ZDq8c44RRKCFFNI4GYGDA4yS6C6Sy3DVGv2yTQpB2zjvHG37HEjPtlvLYvuEWrYPnYUDEqJ/HRMN3qlODfyr1/+5+4+k8E=
+    - GITHUB_USER=tomster-strudel
+    - secure: A5DKT8O+wmwEY3ReKkBMFgy+r2EaUgxMd9FMR+MOGLWMzVdEm6QX0tQopWgqpoPLpymr6aUNMYrb3mRoYygBpUaobgrRRh2f+IGQ+i65+gqC+Y8ma8sArbAKVZ+QuV42ICPGTtk2ep9nQ81k1NO714iOaok4jBuTPFrIOEFx4NSWOuxAHSyjpb41YcoZ4420taXOT6PEtU528lAeLTZeI/gfn/TyDFS5Hf+CoFHxZgLZ+gtdJugu4+11KLnOPgCsAmL2AKagk3LQzfHgaASME4GqXDwz5iBloMWeP2RJJQxwUtB/XgPz//VLh1nOdfodhRy0pjeRzrgvoMYiyqKvG1UMCqjqz/WEYtdeR335NC3kPv9tCcMCeN6vvCaKoang9i+LGEFLzj+zN50ldLMfkF/YEu/PkmezYLWpQwZdlwGQpZjLabT0etS46rdSIDU3M/4N4Waj3o9G8ZXgx7fTOd9ypRPbvOBslUlzup+jMLfGoKLcdT7Cmd3qTJ7XAWFRTTGA/fM7Bd8SYY1FQBAEsHH+2HqF0RsdSAnNpXQtVdzs5TjS9jzLM2rG4S2p0Dly7fe0KgYBD/X21ZDq8c44RRKCFFNI4GYGDA4yS6C6Sy3DVGv2yTQpB2zjvHG37HEjPtlvLYvuEWrYPnYUDEqJ/HRMN3qlODfyr1/+5+4+k8E=
+
 matrix:
   fast_finish: true
   allow_failures:
-  - env: EMBER_TRY_SCENARIO=ember-beta
-  - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.12 # TODO fix this
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.16 # TODO fix this
+    - env: EMBER_TRY_SCENARIO=ember-release # TODO fix this
+    - env: EMBER_TRY_SCENARIO=ember-beta # TODO fix this
+    - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,36 +1,119 @@
 /*jshint node:true*/
 module.exports = {
+  useYarn: true,
   scenarios: [
     {
       name: 'default',
       dependencies: { }
     },
-    // {
-    //   name: 'ember-release',
-    //   dependencies: {
-    //     'ember': 'components/ember#release'
-    //   },
-    //   resolutions: {
-    //     'ember': 'release'
-    //   }
-    // },
-    // {
-    //   name: 'ember-beta',
-    //   dependencies: {
-    //     'ember': 'components/ember#beta'
-    //   },
-    //   resolutions: {
-    //     'ember': 'beta'
-    //   }
-    // },
-    // {
-    //   name: 'ember-canary',
-    //   dependencies: {
-    //     'ember': 'components/ember#canary'
-    //   },
-    //   resolutions: {
-    //     'ember': 'canary'
-    //   }
-    // }
+    {
+      name: 'ember-2.0',
+      bower: {
+        dependencies: {
+          ember: '~2.0.0',
+        },
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null,
+        },
+      },
+    },
+    {
+      name: 'ember-lts-2.4',
+      bower: {
+        dependencies: {
+          ember: 'components/ember#lts-2-4',
+        },
+        resolutions: {
+          ember: 'lts-2-4',
+        },
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null,
+        },
+      },
+    },
+    {
+      name: 'ember-lts-2.8',
+      bower: {
+        dependencies: {
+          ember: 'components/ember#lts-2-8',
+        },
+        resolutions: {
+          ember: 'lts-2-8',
+        },
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null,
+        },
+      },
+    },
+    {
+      name: 'ember-lts-2.12',
+      npm: {
+        devDependencies: {
+          'ember-source': '~2.12.0',
+        },
+      },
+    },
+    {
+      name: 'ember-lts-2.16',
+      npm: {
+        devDependencies: {
+          'ember-source': '~2.16.0-beta.1',
+        },
+      },
+    },
+    {
+      name: 'ember-release',
+      bower: {
+        dependencies: {
+          ember: 'components/ember#release',
+        },
+        resolutions: {
+          ember: 'release',
+        },
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null,
+        },
+      },
+    },
+    {
+      name: 'ember-beta',
+      bower: {
+        dependencies: {
+          ember: 'components/ember#beta',
+        },
+        resolutions: {
+          ember: 'beta',
+        },
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null,
+        },
+      },
+    },
+    {
+      name: 'ember-canary',
+      bower: {
+        dependencies: {
+          ember: 'components/ember#canary',
+        },
+        resolutions: {
+          ember: 'canary',
+        },
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null,
+        },
+      },
+    },
   ]
 };

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -11,10 +11,14 @@ module.exports = {
       bower: {
         dependencies: {
           ember: '~2.0.0',
+          'ember-cli-shims': '0.0.6',
+          'ember-data': '~2.0.0',
         },
       },
       npm: {
         devDependencies: {
+          'ember-cli-shims': null,
+          'ember-data': '~2.0.0',
           'ember-source': null,
         },
       },
@@ -24,6 +28,7 @@ module.exports = {
       bower: {
         dependencies: {
           ember: 'components/ember#lts-2-4',
+          'ember-cli-shims': '0.1.0',
         },
         resolutions: {
           ember: 'lts-2-4',
@@ -31,6 +36,8 @@ module.exports = {
       },
       npm: {
         devDependencies: {
+          'ember-cli-shims': null,
+          'ember-data': '~2.4.0',
           'ember-source': null,
         },
       },
@@ -47,6 +54,7 @@ module.exports = {
       },
       npm: {
         devDependencies: {
+          'ember-data': '~2.8.0',
           'ember-source': null,
         },
       },
@@ -55,6 +63,7 @@ module.exports = {
       name: 'ember-lts-2.12',
       npm: {
         devDependencies: {
+          'ember-data': '~2.12.0',
           'ember-source': '~2.12.0',
         },
       },
@@ -63,6 +72,7 @@ module.exports = {
       name: 'ember-lts-2.16',
       npm: {
         devDependencies: {
+          'ember-data': '~2.16.0',
           'ember-source': '~2.16.0-beta.1',
         },
       },
@@ -79,6 +89,7 @@ module.exports = {
       },
       npm: {
         devDependencies: {
+          'ember-data': 'emberjs/data#release',
           'ember-source': null,
         },
       },
@@ -95,6 +106,7 @@ module.exports = {
       },
       npm: {
         devDependencies: {
+          'ember-data': 'emberjs/data#beta',
           'ember-source': null,
         },
       },
@@ -111,6 +123,7 @@ module.exports = {
       },
       npm: {
         devDependencies: {
+          'ember-data': 'emberjs/data#master',
           'ember-source': null,
         },
       },


### PR DESCRIPTION
This adds `ember-try` scenarios for Ember 2.0, 2.4, 2.8, 2.12 and 2.16. It also enables the scenarios so that they run on CI. Ember 2.12 and above are currently failing due to a broken container access so I added them to `allow_failures` for now.