### PR TITLE
NodeJs: Update support policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-- '4'
-sudo: false
+  - "10"
 
 cache:
   yarn: true

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "ember try:testall"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "10.* || 12.* || >= 14"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
## Current issue

CI fails because latest yarn is installed and run there. yarn is now incompatible with Node 4.

## A fix

This PR proposes to drop support for NodeJs versions < 10, 11 and 13.

## Links

It would unblock
- https://github.com/ember-data/active-model-adapter/pull/130
- Dependabot upgrades.