### PR TITLE
Add @ember/string to avoid deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "postpack": "ember ts:clean"
   },
   "dependencies": {
+    "@ember/string": "^3.0.0",
     "ember-auto-import": "^2.4.0",
     "ember-cli-babel": "^7.26.10",
     "ember-cli-htmlbars": "^5.7.2",


### PR DESCRIPTION
Importing from @ember/string without the @ember/string package as a dependency is deprecated.

https://deprecations.emberjs.com/v4.x#toc_ember-string-add-package
