### PR TITLE
Fix ember-data 5.0 warning, use local copy of errorsHashToArray

### DIFF
--- a/addon/active-model-adapter.ts
+++ b/addon/active-model-adapter.ts
@@ -1,7 +1,6 @@
 import RESTAdapter from '@ember-data/adapter/rest';
 import AdapterError, {
   InvalidError,
-  errorsHashToArray,
 } from '@ember-data/adapter/error';
 import { pluralize } from 'ember-inflector';
 import { AnyObject } from 'active-model-adapter';
@@ -16,6 +15,44 @@ interface ActiveModelPayload {
 /**
   @module ember-data
 */
+
+const PRIMARY_ATTRIBUTE_KEY = 'base';
+function makeArray<T>(value: T | T[]): T[] {
+  return Array.isArray(value) ? value : [value];
+}
+type JsonApiError = Record<string, unknown>
+/**
+ * Copied from ember-data's 4.12.4 implementation after removal in ember-data 5.0
+ * https://github.com/emberjs/data/blob/a0d60c073bc03631277b258aaaadfc910e0a31dc/packages/adapter/src/error.js#L395-L429
+ * Types inferred from similar private function
+ * https://github.com/emberjs/data/blob/84a15401a7d2a6f8a7efcc2492834c80a27afcc0/packages/legacy-compat/src/legacy-network-handler/legacy-network-handler.ts#L265-L289
+ */
+function errorsHashToArray(errors: Record<string, string | string[]>): JsonApiError[] {
+  const out: JsonApiError[] = [];
+
+  if (errors) {
+    Object.keys(errors).forEach((key) => {
+      const messages = makeArray(errors[key]);
+      for (let i = 0; i < messages.length; i++) {
+        let title = 'Invalid Attribute';
+        let pointer = `/data/attributes/${key}`;
+        if (key === PRIMARY_ATTRIBUTE_KEY) {
+          title = 'Invalid Document';
+          pointer = `/data`;
+        }
+        out.push({
+          title: title,
+          detail: messages[i],
+          source: {
+            pointer: pointer,
+          },
+        });
+      }
+    });
+  }
+
+  return out;
+}
 
 /**
  * The ActiveModelAdapter is a subclass of the RESTAdapter designed to integrate

--- a/addon/active-model-adapter.ts
+++ b/addon/active-model-adapter.ts
@@ -27,7 +27,7 @@ type JsonApiError = Record<string, unknown>
  * Types inferred from similar private function
  * https://github.com/emberjs/data/blob/84a15401a7d2a6f8a7efcc2492834c80a27afcc0/packages/legacy-compat/src/legacy-network-handler/legacy-network-handler.ts#L265-L289
  */
-function errorsHashToArray(errors: Record<string, string | string[]>): JsonApiError[] {
+function errorsHashToArray(errors: Record<string, unknown | unknown[]>): JsonApiError[] {
   const out: JsonApiError[] = [];
 
   if (errors) {


### PR DESCRIPTION
Building an application with ember-data 5 and this addon results in this warning;

```
WARNING in ../rewritten-packages/active-model-adapter.621d47ca/active-model-adapter.js 172:21-38
export 'errorsHashToArray' (imported as 'errorsHashToArray') was not found in '@ember-data/adapter/error' (possible exports: AbortError, ConflictError, ForbiddenError, InvalidError, NotFoundError, ServerError, TimeoutError, UnauthorizedError, default)
 @ ../rewritten-packages/active-model-adapter.621d47ca/index.js 1:0-56 3:15-33 4:0-53
 @ ./assignment/adapter.js 7:0-54 40:66-84
 @ ./tests/co-located/assignment/adapter-test.js 3:0-75 14:16-35 25:16-35 36:16-35 47:16-35
 @ ./assets/test.js 193:13-85
```

As mentioned in the deprecation, `errorsHashToArray` is dropped in ember-data 5
https://deprecations.emberjs.com/ember-data/v4.x/#toc_ember-data-deprecate-errors-hash-to-array-helper

The recommendation is to replace it with a local copy
> Users making use of these (already private) utilities can trivially copy them into their own codebase to continue using them