### PR TITLE
chore: add root entry for pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
+  - .
   - 'classic-test-app'


### PR DESCRIPTION
pnpm-workspace.yaml was missing a `.` to indicate a root package (the actual `active-model-adapter` addon) in the workspace